### PR TITLE
Allow php nightly build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - '7.0'
   - hhvm
   - nightly
+matrix:
+  allow_failures:
+    - php: nightly
 install:
   - composer install --dev
 script: ant


### PR DESCRIPTION
It's often interesting to see the code running against nightly but I'm not sure if there's much value to considering it as a "failure"
