### PR TITLE
use phing for build process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ php:
   - nightly
 install:
   - composer install --dev
-script: ant
+script: vendor/bin/phing

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,17 @@
     <!-- Execute code style check. -->
     <target name="phpcs">
         <echo>Running PHP PSR-2 code style checks.</echo>
-        <exec executable="vendor/bin/phpcs" failonerror="true">
+        <exec executable="vendor/bin/phpcs" passthru="true">
+            <arg value="--colors" />
+            <arg value="--standard=PSR2" />
+            <arg value="src" />
+        </exec>
+    </target>
+
+    <!-- Execute code style fix -->
+    <target name="phpcbf">
+        <echo>Running PHP PSR-2 code style fixes.</echo>
+        <exec executable="vendor/bin/phpcbf" passthru="true">
             <arg value="--colors" />
             <arg value="--standard=PSR2" />
             <arg value="src" />
@@ -13,7 +23,7 @@
     <!-- Execute PHP linting. -->
     <target name="phplint">
         <echo>Running PHP parallel linter.</echo>
-        <exec executable="vendor/bin/parallel-lint" failonerror="true">
+        <exec executable="vendor/bin/parallel-lint" passthru="true">
             <arg value="src" />
         </exec>
     </target>
@@ -21,7 +31,7 @@
     <!-- Execute PHPUnit tests. -->
     <target name="phpunit">
         <echo>Running PHP Unit tests.</echo>
-        <exec executable="vendor/bin/phpunit" failonerror="true">
+        <exec executable="vendor/bin/phpunit" passthru="true">
             <arg value="--color" />
         </exec>
     </target>

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,5 @@
         "psr-4": {
             "Scientist\\": "src"
         }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "": "tests"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,17 @@
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
         "squizlabs/php_codesniffer": "^2.5",
-        "jakub-onderka/php-parallel-lint": "^0.9.2"
+        "jakub-onderka/php-parallel-lint": "^0.9.2",
+        "phing/phing": "^2.13"
     },
     "autoload": {
         "psr-4": {
             "Scientist\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "": "tests"
         }
     }
 }


### PR DESCRIPTION
This is a PHP library, lets make building easier for PHP devs by using the build tool for PHP.

Changes
- Removed `failonerror` as it is not compatible with Phing. 
- Added a `phpcbf` target for fixing the coding style issues.
- added `passthru = true` on execs to show output
