### PR TITLE
[ENHANCEMENT] Studies for class experiments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.5",
+        "zendframework/zend-code": ">=2"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
@@ -21,6 +22,11 @@
     "autoload": {
         "psr-4": {
             "Scientist\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "": "tests"
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,4 +13,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Blind.php
+++ b/src/Blind.php
@@ -3,7 +3,6 @@
 
 namespace Scientist;
 
-
 interface Blind
 {
 

--- a/src/Blind.php
+++ b/src/Blind.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Scientist;
+
+
+interface Blind
+{
+
+}

--- a/src/Blind/DecoratorTrait.php
+++ b/src/Blind/DecoratorTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+
+namespace Scientist\Blind;
+
+
+use Scientist\Experiment;
+use Scientist\Study;
+
+trait DecoratorTrait
+{
+    /** @var  Study */
+    private $study;
+    /** @var Experiment[] */
+    private $experiments = [];
+
+    /**
+     * @param string $method
+     * @return string
+     */
+    private function getExperimentNameForMethod($method)
+    {
+        return sprintf("%s::%s", $this->study->getName(), $method);
+    }
+
+    /**
+     * @param string $attribute
+     * @return string
+     */
+    private function getExperimentNameForAttribute($attribute)
+    {
+        return sprintf("%s::\$%s", $this->study->getName(), $attribute);
+    }
+
+    /**
+     * @param string $name
+     * @return Experiment
+     */
+    private function getExperiment($name) {
+        return $this->experiments[$name];
+    }
+
+    /**
+     * DecoratorTrait constructor.
+     * @param Study $study
+     * @param Experiment[] $experiments
+     */
+    function __construct(Study $study, array $experiments = [])
+    {
+        $this->study = $study;
+        foreach($experiments as $experiment) {
+            $this->experiments[$experiment->getName()] = $experiment;
+        }
+    }
+
+    function __call($name, $arguments)
+    {
+        $experiment = $this->getExperiment($this->getExperimentNameForMethod($name));
+        return call_user_func_array([$experiment, 'run'], $arguments);
+    }
+
+    function __get($name)
+    {
+        $experiment = $this->getExperiment($this->getExperimentNameForAttribute($name));
+        return call_user_func_array([$experiment, 'run'], [$name]);
+    }
+
+    function __set($name, $value)
+    {
+        $experiment = $this->getExperiment($this->getExperimentNameForAttribute($name));
+        return call_user_func_array([$experiment, 'run'], [$name, $value]);
+    }
+
+    function __isset($name)
+    {
+        $value = $this->__get($name);
+        return $value !== null;
+    }
+
+    function __unset($name)
+    {
+        $this->__set($name, null);
+    }
+
+    function __toString()
+    {
+        $experiment = $this->getExperiment($this->getExperimentNameForMethod('__toString'));
+        return call_user_func([$experiment, 'run']);
+    }
+
+    function __invoke()
+    {
+        $arguments = func_get_args();
+        $experiment = $this->getExperiment($this->getExperimentNameForMethod('__invoke'));
+        return call_user_func_array([$experiment, 'run'], $arguments);
+    }
+}

--- a/src/Blind/DecoratorTrait.php
+++ b/src/Blind/DecoratorTrait.php
@@ -3,7 +3,6 @@
 
 namespace Scientist\Blind;
 
-
 use Scientist\Experiment;
 use Scientist\Study;
 
@@ -36,7 +35,8 @@ trait DecoratorTrait
      * @param string $name
      * @return Experiment
      */
-    private function getExperiment($name) {
+    private function getExperiment($name)
+    {
         return $this->experiments[$name];
     }
 
@@ -48,7 +48,7 @@ trait DecoratorTrait
     function __construct(Study $study, array $experiments = [])
     {
         $this->study = $study;
-        foreach($experiments as $experiment) {
+        foreach ($experiments as $experiment) {
             $this->experiments[$experiment->getName()] = $experiment;
         }
     }

--- a/src/Blind/Preparation.php
+++ b/src/Blind/Preparation.php
@@ -3,7 +3,6 @@
 
 namespace Scientist\Blind;
 
-
 use ReflectionClass;
 use ReflectionProperty;
 use Scientist\Blind;
@@ -43,8 +42,8 @@ class Preparation
 
         array_push($interfaces, Blind::class);
 
-        foreach($interfaces as &$interface) {
-            if(strpos($interface, '\\') !== 0) {
+        foreach ($interfaces as &$interface) {
+            if (strpos($interface, '\\') !== 0) {
                 $interface = '\\'.$interface;
             }
         }
@@ -72,10 +71,10 @@ class Preparation
     {
         $experiments = [];
         $reflection = new ReflectionClass($control);
-        foreach($reflection->getMethods() as $method) {
+        foreach ($reflection->getMethods() as $method) {
             $experiments[] = $this->createMethodExperiment($method->getName(), $study, $control, $trials);
         }
-        foreach($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
             $experiments[] = $this->createPropertyExperiment($property->getName(), $study, $control, $trials);
         }
         return $experiments;
@@ -97,8 +96,8 @@ class Preparation
 
         $experiment->control([$control, $name]);
 
-        foreach($trials as $trial_name => $trial) {
-            if(method_exists($trial, $name)){
+        foreach ($trials as $trial_name => $trial) {
+            if (method_exists($trial, $name)) {
                 $experiment->trial($trial_name, [$trial, $name]);
             } else {
                 $experiment->trial($trial_name, $this->createMissingMethodCallable($trial, $name));
@@ -120,8 +119,8 @@ class Preparation
 
         $experiment->control($this->createPropertyCallable($control, $name));
 
-        foreach($trials as $trial_name => $trial) {
-            if(property_exists($trial, $name)){
+        foreach ($trials as $trial_name => $trial) {
+            if (property_exists($trial, $name)) {
                 $experiment->trial($trial_name, $this->createPropertyCallable($trial, $name));
             } else {
                 $experiment->trial($trial_name, $this->createMissingPropertyCallable($trial, $name));
@@ -141,10 +140,10 @@ class Preparation
      */
     private function createPropertyCallable($instance, $name)
     {
-        return function() use ($instance, $name) {
+        return function () use ($instance, $name) {
             $args = func_get_args();
             // __set
-            if(count($args) > 1) {
+            if (count($args) > 1) {
                 list($name, $value) = $args;
                 return $instance->{$name} = $value;
             }
@@ -156,14 +155,14 @@ class Preparation
 
     private function createMissingPropertyCallable($instance, $name)
     {
-        return function() use ($instance, $name) {
+        return function () use ($instance, $name) {
             throw new MissingProperty($instance, $name);
         };
     }
 
     private function createMissingMethodCallable($instance, $name)
     {
-        return function() use ($instance, $name) {
+        return function () use ($instance, $name) {
             throw new MissingMethod($instance, $name);
         };
     }
@@ -176,9 +175,9 @@ class Preparation
     return call_user_func_array([$experiment, 'run'], $arguments);
 PHP;
 
-        foreach($interfaces as $interface) {
+        foreach ($interfaces as $interface) {
             $reflection = new ClassReflection($interface);
-            foreach($reflection->getMethods() as $method) {
+            foreach ($reflection->getMethods() as $method) {
                 $generator = MethodGenerator::fromReflection($method);
                 $generator->setInterface(false);
                 $generator->setBody(sprintf($template, $method->getName()));
@@ -186,5 +185,4 @@ PHP;
             }
         }
     }
-
 }

--- a/src/Blind/Preparation.php
+++ b/src/Blind/Preparation.php
@@ -1,0 +1,153 @@
+<?php
+
+
+namespace Scientist\Blind;
+
+
+use ReflectionClass;
+use ReflectionProperty;
+use Scientist\Experiment;
+use Scientist\SideEffects\MissingMethod;
+use Scientist\SideEffects\MissingProperty;
+use Scientist\Study;
+
+class Preparation
+{
+    /**
+     * @param Study $study
+     * @param mixed $control
+     * @param mixed[] $trials
+     */
+    public function prepare(Study $study, $control, array $trials)
+    {
+        $experiments = $this->createExperiments($study, $control, $trials);
+        return $this->createBlind($study, $control, $experiments);
+    }
+
+    private function createBlind($study, $control, array $experiments)
+    {
+        $blind_name = sprintf("Blind_%s", str_replace('.', '', uniqid('', true)));
+        $template = <<<'PHP'
+namespace Scientist\Blind;
+class %s extends \%s {
+    use \Scientist\Blind\DecoratorTrait;
+}
+PHP;
+        $blind_definition = sprintf($template,
+            $blind_name,
+            get_class($control)
+            );
+
+        eval($blind_definition);
+
+        $class_name = sprintf('Scientist\Blind\%s', $blind_name);
+        return new $class_name($study, $experiments);
+    }
+
+    /**
+     * @param $study
+     * @param $control
+     * @param array $trials
+     * @return array
+     */
+    private function createExperiments(Study $study, $control, array $trials)
+    {
+        $experiments = [];
+        $reflection = new ReflectionClass($control);
+        foreach($reflection->getMethods() as $method) {
+            $experiments[] = $this->createMethodExperiment($method->getName(), $study, $control, $trials);
+        }
+        foreach($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $experiments[] = $this->createPropertyExperiment($property->getName(), $study, $control, $trials);
+        }
+        return $experiments;
+    }
+
+    /**
+     * @param string $name
+     * @param Study $study
+     * @param mixed $control
+     * @param mixed[] $trials
+     * @return Experiment
+     */
+    private function createMethodExperiment($name, Study $study, $control, array $trials)
+    {
+        $experiment_name = sprintf('%s::%s', $study->getName(), $name);
+        /** @var Experiment $experiment */
+        $experiment = $study->getLaboratory()
+            ->experiment($experiment_name);
+
+        $experiment->control([$control, $name]);
+
+        foreach($trials as $trial_name => $trial) {
+            if(method_exists($trial, $name)){
+                $experiment->trial($trial_name, [$trial, $name]);
+            } else {
+                $experiment->trial($trial_name, $this->createMissingMethodCallable($trial, $name));
+            }
+        }
+
+        $experiment->matcher($study->getMatcher());
+        $experiment->chance($study->getChance());
+        $study->addExperiment($experiment);
+        return $experiment;
+    }
+
+    private function createPropertyExperiment($name, Study $study, $control, array $trials)
+    {
+        $experiment_name = sprintf('%s::$%s', $study->getName(), $name);
+        /** @var Experiment $experiment */
+        $experiment = $study->getLaboratory()
+            ->experiment($experiment_name);
+
+        $experiment->control($this->createPropertyCallable($control, $name));
+
+        foreach($trials as $trial_name => $trial) {
+            if(property_exists($trial, $name)){
+                $experiment->trial($trial_name, $this->createPropertyCallable($trial, $name));
+            } else {
+                $experiment->trial($trial_name, $this->createMissingPropertyCallable($trial, $name));
+            }
+        }
+
+        $experiment->matcher($study->getMatcher());
+        $experiment->chance($study->getChance());
+        $study->addExperiment($experiment);
+        return $experiment;
+    }
+
+    /**
+     * @param mixed $instance
+     * @param string $name
+     * @return callable
+     */
+    private function createPropertyCallable($instance, $name)
+    {
+        return function() use ($instance, $name) {
+            $args = func_get_args();
+            // __set
+            if(count($args) > 1) {
+                list($name, $value) = $args;
+                return $instance->{$name} = $value;
+            }
+            // __get
+            $name = $args[0];
+            return $instance->{$name};
+        };
+    }
+
+    private function createMissingPropertyCallable($instance, $name)
+    {
+        return function() use ($instance, $name) {
+            throw new MissingProperty($instance, $name);
+        };
+    }
+
+    private function createMissingMethodCallable($instance, $name)
+    {
+        return function() use ($instance, $name) {
+            throw new MissingMethod($instance, $name);
+        };
+    }
+
+}

--- a/src/SideEffects/MissingMethod.php
+++ b/src/SideEffects/MissingMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Scientist\SideEffects;
+
+
+class MissingMethod extends \RuntimeException
+{
+    /**
+     * MissingMethod constructor.
+     * @param mixed $instance
+     * @param string $method
+     */
+    public function __construct($instance, $method)
+    {
+        parent::__construct(sprintf("%s does not implement method %s",
+            get_class($instance),
+            $method
+        ));
+    }
+}

--- a/src/SideEffects/MissingMethod.php
+++ b/src/SideEffects/MissingMethod.php
@@ -3,7 +3,6 @@
 
 namespace Scientist\SideEffects;
 
-
 class MissingMethod extends \RuntimeException
 {
     /**
@@ -13,7 +12,8 @@ class MissingMethod extends \RuntimeException
      */
     public function __construct($instance, $method)
     {
-        parent::__construct(sprintf("%s does not implement method %s",
+        parent::__construct(sprintf(
+            "%s does not implement method %s",
             get_class($instance),
             $method
         ));

--- a/src/SideEffects/MissingProperty.php
+++ b/src/SideEffects/MissingProperty.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Scientist\SideEffects;
+
+
+class MissingProperty extends \RuntimeException
+{
+    /**
+     * MissingProperty constructor.
+     * @param string $instance
+     * @param string $property
+     */
+    public function __construct($instance, $property)
+    {
+        parent::__construct(sprintf("%s does not implement property %s",
+            get_class($instance),
+            $property
+            ));
+    }
+}

--- a/src/SideEffects/MissingProperty.php
+++ b/src/SideEffects/MissingProperty.php
@@ -3,7 +3,6 @@
 
 namespace Scientist\SideEffects;
 
-
 class MissingProperty extends \RuntimeException
 {
     /**
@@ -13,9 +12,10 @@ class MissingProperty extends \RuntimeException
      */
     public function __construct($instance, $property)
     {
-        parent::__construct(sprintf("%s does not implement property %s",
+        parent::__construct(sprintf(
+            "%s does not implement property %s",
             get_class($instance),
             $property
-            ));
+        ));
     }
 }

--- a/src/Study.php
+++ b/src/Study.php
@@ -77,14 +77,6 @@ class Study
     }
 
     /**
-     * @param string $name
-     */
-    public function setName($name)
-    {
-        $this->name = $name;
-    }
-
-    /**
      * @return mixed
      */
     public function getControl()

--- a/src/Study.php
+++ b/src/Study.php
@@ -3,7 +3,6 @@
 
 namespace Scientist;
 
-
 use Scientist\Blind\Preparation;
 use Scientist\Matchers\StandardMatcher;
 
@@ -202,7 +201,7 @@ class Study
     public function blind($interface = null)
     {
         $interfaces = func_get_args();
-        if($interface == null) {
+        if ($interface == null) {
             array_shift($interfaces);
         }
 

--- a/src/Study.php
+++ b/src/Study.php
@@ -204,11 +204,17 @@ class Study
     }
 
     /**
+     * @param string ...$interface blind will implement the interfaces specified
      * @return mixed
      */
-    public function blind()
+    public function blind($interface = null)
     {
+        $interfaces = func_get_args();
+        if($interface == null) {
+            array_shift($interfaces);
+        }
+
         $preparation = new Preparation();
-        return $preparation->prepare($this, $this->getControl(), $this->getTrials());
+        return $preparation->prepare($this, $this->getControl(), $this->getTrials(), $interfaces);
     }
 }

--- a/src/Study.php
+++ b/src/Study.php
@@ -1,0 +1,214 @@
+<?php
+
+
+namespace Scientist;
+
+
+use Scientist\Blind\Preparation;
+use Scientist\Matchers\StandardMatcher;
+
+class Study
+{
+    /**
+     * Experiment name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The control instance.
+     *
+     * @var mixed
+     */
+    protected $control;
+
+    /**
+     * Trial instances.
+     *
+     * @var array
+     */
+    protected $trials = [];
+
+    /**
+     * Laboratory instance.
+     *
+     * @var \Scientist\Laboratory|null
+     */
+    protected $laboratory;
+
+    /**
+     * Matcher for experiment values.
+     *
+     * @var \Scientist\Matchers\Matcher
+     */
+    protected $matcher;
+
+    /**
+     * Execution chance.
+     *
+     * @var integer
+     */
+    protected $chance = 100;
+
+    /**
+     * @var Experiment[]
+     */
+    protected $experiments = [];
+
+    /**
+     * Study constructor.
+     * @param string $name
+     * @param null|Laboratory $laboratory
+     */
+    public function __construct($name, $laboratory = null)
+    {
+        $this->name = $name;
+        $this->laboratory = $laboratory;
+        $this->matcher = new StandardMatcher;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getControl()
+    {
+        return $this->control;
+    }
+
+    /**
+     * @param mixed $control
+     * @return $this
+     */
+    public function control($control)
+    {
+        $this->control = $control;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTrials()
+    {
+        return $this->trials;
+    }
+
+    /**
+     * @param string $name
+     * @return mixed
+     */
+    public function getTrial($name)
+    {
+        return $this->trials[$name];
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $trial
+     * @return $this
+     */
+    public function trial($name, $trial)
+    {
+        $this->trials[$name] = $trial;
+        return $this;
+    }
+
+    /**
+     * @return null|Laboratory
+     */
+    public function getLaboratory()
+    {
+        return $this->laboratory;
+    }
+
+    /**
+     * @param null|Laboratory $laboratory
+     */
+    public function setLaboratory($laboratory)
+    {
+        $this->laboratory = $laboratory;
+    }
+
+    /**
+     * @return Matchers\Matcher
+     */
+    public function getMatcher()
+    {
+        return $this->matcher;
+    }
+
+    /**
+     * @param Matchers\Matcher $matcher
+     */
+    public function setMatcher($matcher)
+    {
+        $this->matcher = $matcher;
+    }
+
+    /**
+     * @return int
+     */
+    public function getChance()
+    {
+        return $this->chance;
+    }
+
+    /**
+     * @param int $chance
+     */
+    public function setChance($chance)
+    {
+        $this->chance = $chance;
+    }
+
+    /**
+     * @return Experiment[]
+     */
+    public function getExperiments()
+    {
+        return $this->experiments;
+    }
+
+    /**
+     * @param string $name
+     * @return Experiment
+     */
+    public function getExperiment($name)
+    {
+        return $this->experiments[$name];
+    }
+
+    /**
+     * @param Experiment $experiment
+     */
+    public function addExperiment(Experiment $experiment)
+    {
+        $this->experiments[$experiment->getName()] = $experiment;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function blind()
+    {
+        $preparation = new Preparation();
+        return $preparation->prepare($this, $this->getControl(), $this->getTrials());
+    }
+}

--- a/tests/Blind/BehaviorAsset.php
+++ b/tests/Blind/BehaviorAsset.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Blind;
+
+
+interface BehaviorAsset
+{
+
+}

--- a/tests/Blind/BlindAsset.php
+++ b/tests/Blind/BlindAsset.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Blind;
+
+
+use Scientist\Blind\DecoratorTrait;
+
+class BlindAsset
+{
+    use DecoratorTrait;
+}

--- a/tests/Blind/PreparationTest.php
+++ b/tests/Blind/PreparationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 
+use Blind\BehaviorAsset;
+use Scientist\Blind;
 use Scientist\Blind\DecoratorTrait;
 use Scientist\Blind\Preparation;
 use Scientist\Experiment;
@@ -27,14 +29,23 @@ class PreparationTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Experiment::class, $study->getExperiment('test::$attribute'));
     }
 
-    public function test_preparation_decorates_experiments_in_a_control_extension()
+    public function test_preparation_returns_a_blind()
     {
         $preparation = new Preparation();
         $blind = $preparation->prepare($study = new Study('test', new Laboratory()), new ControlAsset, [new TrialAsset]);
 
-        $this->assertInstanceOf(ControlAsset::class, $blind);
+        $this->assertInstanceOf(Blind::class, $blind);
+    }
 
-        $reflection = new ReflectionClass($blind);
-        $this->assertTrue(in_array(DecoratorTrait::class, $reflection->getTraitNames()));
+    public function test_preparation_returns_a_blind_that_implements_interfaces()
+    {
+        $preparation = new Preparation();
+        $blind = $preparation->prepare($study = new Study('test',
+            new Laboratory()),
+            new ControlAsset,
+            [new TrialAsset],
+            [BehaviorAsset::class]);
+
+        $this->assertInstanceOf(BehaviorAsset::class, $blind);
     }
 }

--- a/tests/Blind/PreparationTest.php
+++ b/tests/Blind/PreparationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+
+use Scientist\Blind\DecoratorTrait;
+use Scientist\Blind\Preparation;
+use Scientist\Experiment;
+use Scientist\Laboratory;
+use Scientist\Study;
+use Study\ControlAsset;
+use Study\TrialAsset;
+
+class PreparationTest extends PHPUnit_Framework_TestCase
+{
+    public function test_preparation_creates_experiments_for_public_methods()
+    {
+        $preparation = new Preparation();
+        $preparation->prepare($study = new Study('test', new Laboratory()), new ControlAsset, [new TrialAsset]);
+
+        $this->assertInstanceOf(Experiment::class, $study->getExperiment('test::behavior'));
+    }
+
+    public function test_preparation_creates_experiments_for_public_attributes()
+    {
+        $preparation = new Preparation();
+        $preparation->prepare($study = new Study('test', new Laboratory()), new ControlAsset, [new TrialAsset]);
+
+        $this->assertInstanceOf(Experiment::class, $study->getExperiment('test::$attribute'));
+    }
+
+    public function test_preparation_decorates_experiments_in_a_control_extension()
+    {
+        $preparation = new Preparation();
+        $blind = $preparation->prepare($study = new Study('test', new Laboratory()), new ControlAsset, [new TrialAsset]);
+
+        $this->assertInstanceOf(ControlAsset::class, $blind);
+
+        $reflection = new ReflectionClass($blind);
+        $this->assertTrue(in_array(DecoratorTrait::class, $reflection->getTraitNames()));
+    }
+}

--- a/tests/BlindTest.php
+++ b/tests/BlindTest.php
@@ -1,0 +1,78 @@
+<?php
+
+
+use Blind\BlindAsset;
+use Scientist\Experiment;
+use Scientist\Study;
+
+class BlindTest extends PHPUnit_Framework_TestCase
+{
+    public function test_that_blind_maps_public_method_calls_to_experiment()
+    {
+        $experimentMock = $this->getMockBuilder(Experiment::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $experimentMock->expects($this->any())
+            ->method('getName')
+            ->willReturn('test::method');
+        $experimentMock->expects($this->once())
+            ->method('run')
+            ->with('foo')
+            ->willReturn('bar');
+
+        $blind = new BlindAsset(new Study('test'), [$experimentMock]);
+        $this->assertEquals('bar', $blind->method('foo'));
+    }
+
+    public function test_that_blind_maps_public_attribute_access_to_experiment()
+    {
+        $experimentMock = $this->getMockBuilder(Experiment::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $experimentMock->expects($this->any())
+            ->method('getName')
+            ->willReturn('test::$attribute');
+        $experimentMock->expects($this->exactly(2))
+            ->method('run')
+            ->withConsecutive(['attribute'], ['attribute', 'baz'])
+            ->willReturnOnConsecutiveCalls('bar', 'baz');
+
+        $blind = new BlindAsset(new Study('test'), [$experimentMock]);
+        $this->assertEquals('bar', $blind->attribute);
+        $this->assertEquals('baz', $blind->attribute = 'baz');
+    }
+
+    public function test_that_blind_maps_isset_to_attribute_experiment()
+    {
+        $experimentMock = $this->getMockBuilder(Experiment::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $experimentMock->expects($this->any())
+            ->method('getName')
+            ->willReturn('test::$attribute');
+        $experimentMock->expects($this->exactly(2))
+            ->method('run')
+            ->with('attribute')
+            ->willReturnOnConsecutiveCalls(null, 'fiz');
+
+        $blind = new BlindAsset(new Study('test'), [$experimentMock]);
+        $this->assertFalse(isset($blind->attribute));
+        $this->assertTrue(isset($blind->attribute));
+    }
+
+    public function test_that_blind_maps_unset_to_attribute_experiment()
+    {
+        $experimentMock = $this->getMockBuilder(Experiment::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $experimentMock->expects($this->any())
+            ->method('getName')
+            ->willReturn('test::$attribute');
+        $experimentMock->expects($this->once())
+            ->method('run')
+            ->with('attribute', null);
+
+        $blind = new BlindAsset(new Study('test'), [$experimentMock]);
+        unset($blind->attribute);
+    }
+}

--- a/tests/Study/ControlAsset.php
+++ b/tests/Study/ControlAsset.php
@@ -4,9 +4,10 @@ namespace Study;
 
 class ControlAsset
 {
-    public $attribute;
+    public $attribute = 'fiz';
 
     public function behavior()
     {
+        return 'foo';
     }
 }

--- a/tests/Study/ControlAsset.php
+++ b/tests/Study/ControlAsset.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Study;
+
+class ControlAsset
+{
+    public $attribute;
+
+    public function behavior()
+    {
+    }
+}

--- a/tests/Study/SideEffectTrialAsset.php
+++ b/tests/Study/SideEffectTrialAsset.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Study;
+
+
+class SideEffectTrialAsset
+{
+
+}

--- a/tests/Study/TrialAsset.php
+++ b/tests/Study/TrialAsset.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Study;
+
+class TrialAsset
+{
+
+}

--- a/tests/Study/TrialAsset.php
+++ b/tests/Study/TrialAsset.php
@@ -4,5 +4,10 @@ namespace Study;
 
 class TrialAsset
 {
+    public $attribute = 'fiz';
 
+    public function behavior()
+    {
+        return 'foo';
+    }
 }

--- a/tests/Study/UnsafeTrialAsset.php
+++ b/tests/Study/UnsafeTrialAsset.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Study;
+
+
+class UnsafeTrialAsset
+{
+    function __get($name)
+    {
+        return 'magic attribute:get';
+    }
+
+    function __set($name, $value)
+    {
+        return 'magic attribute:set';
+    }
+
+
+    public function behavior()
+    {
+        return 'bar';
+    }
+}

--- a/tests/StudyTest.php
+++ b/tests/StudyTest.php
@@ -1,6 +1,8 @@
 <?php
 
 
+use Blind\BehaviorAsset;
+use Scientist\Blind;
 use Scientist\Journals\StandardJournal;
 use Scientist\Laboratory;
 use Scientist\SideEffects\MissingMethod;
@@ -16,9 +18,11 @@ class StudyTest extends PHPUnit_Framework_TestCase
         $blind = (new Study('study', new Laboratory()))
             ->control($control = new ControlAsset)
             ->trial('trial name', new TrialAsset)
-            ->blind();
+            ->blind(BehaviorAsset::class, Iterator::class);
 
-        $this->assertInstanceOf(ControlAsset::class, $blind);
+        $this->assertInstanceOf(Blind::class, $blind);
+        $this->assertInstanceOf(BehaviorAsset::class, $blind);
+        $this->assertInstanceOf(Iterator::class, $blind);
         $this->assertNotSame($control, $blind);
     }
 

--- a/tests/StudyTest.php
+++ b/tests/StudyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+
+use Scientist\Laboratory;
+use Scientist\Study;
+use Study\ControlAsset;
+use Study\TrialAsset;
+
+class StudyTest extends PHPUnit_Framework_TestCase
+{
+    public function test_study_can_prepare_a_blind()
+    {
+        $blind = (new Study('study', new Laboratory()))
+            ->control($control = new ControlAsset)
+            ->trial('trial name', new TrialAsset)
+            ->blind();
+
+        $this->assertInstanceOf(ControlAsset::class, $blind);
+        $this->assertNotSame($control, $blind);
+    }
+
+    public function test_study_aggregates_experiment_reports()
+    {
+        $this->markTestIncomplete('todo');
+    }
+
+    /**
+     * @expectedException \Scientist\SideEffects\MissingMethod
+     */
+    public function test_study_uncovers_missing_method_side_effects()
+    {
+        $blind = (new Study('study', new Laboratory()))
+            ->control($control = new ControlAsset)
+            ->trial('trial name', new TrialAsset)
+            ->blind();
+
+        $blind->behavior();
+    }
+
+    /**
+     * @expectedException \Scientist\SideEffects\MissingProperty
+     */
+    public function test_study_uncovers_missing_property_side_effects()
+    {
+        $blind = (new Study('study', new Laboratory()))
+            ->control($control = new ControlAsset)
+            ->trial('trial name', new TrialAsset)
+            ->blind();
+
+        $blind->attribute;
+    }
+}

--- a/tests/StudyTest.php
+++ b/tests/StudyTest.php
@@ -3,13 +3,17 @@
 
 use Blind\BehaviorAsset;
 use Scientist\Blind;
+use Scientist\Experiment;
 use Scientist\Journals\StandardJournal;
 use Scientist\Laboratory;
+use Scientist\Matchers\StandardMatcher;
 use Scientist\SideEffects\MissingMethod;
 use Scientist\SideEffects\MissingProperty;
 use Scientist\Study;
 use Study\ControlAsset;
+use Study\SideEffectTrialAsset;
 use Study\TrialAsset;
+use Study\UnsafeTrialAsset;
 
 class StudyTest extends PHPUnit_Framework_TestCase
 {
@@ -17,13 +21,54 @@ class StudyTest extends PHPUnit_Framework_TestCase
     {
         $blind = (new Study('study', new Laboratory()))
             ->control($control = new ControlAsset)
-            ->trial('trial name', new TrialAsset)
+            ->trial('trial', new TrialAsset)
+            ->blind();
+
+        $this->assertInstanceOf(Blind::class, $blind);
+        $this->assertNotSame($control, $blind);
+    }
+
+    public function test_study_can_prepare_a_blind_that_satisfies_interfaces()
+    {
+        $blind = (new Study('study', new Laboratory()))
+            ->control($control = new ControlAsset)
+            ->trial('trial', new TrialAsset)
             ->blind(BehaviorAsset::class, Iterator::class);
 
         $this->assertInstanceOf(Blind::class, $blind);
         $this->assertInstanceOf(BehaviorAsset::class, $blind);
         $this->assertInstanceOf(Iterator::class, $blind);
         $this->assertNotSame($control, $blind);
+    }
+
+    public function test_study_shows_trial_is_safe()
+    {
+        $study = new Study('test', new Laboratory());
+        $study->getLaboratory()->addJournal($journal = new StandardJournal());
+        $blind = $study
+            ->control($control = new ControlAsset)
+            ->trial('trial', new TrialAsset())
+            ->blind(BehaviorAsset::class, Iterator::class);
+
+        $blind->behavior();
+        $this->assertTrue($journal->getReport()->getTrial('trial')->isMatch());
+        $blind->attribute = 'foo';
+        $this->assertTrue($journal->getReport()->getTrial('trial')->isMatch());
+    }
+
+    public function test_study_shows_trial_is_unsafe()
+    {
+        $study = new Study('test', new Laboratory());
+        $study->getLaboratory()->addJournal($journal = new StandardJournal());
+        $blind = $study
+            ->control($control = new ControlAsset)
+            ->trial('trial', new UnsafeTrialAsset())
+            ->blind(BehaviorAsset::class, Iterator::class);
+
+        $blind->behavior();
+        $this->assertFalse($journal->getReport()->getTrial('trial')->isMatch());
+        $blind->attribute = 'foo';
+        $this->assertFalse($journal->getReport()->getTrial('trial')->isMatch());
     }
 
     public function test_study_uncovers_missing_method_side_effects()
@@ -33,7 +78,7 @@ class StudyTest extends PHPUnit_Framework_TestCase
 
         $blind = $study
             ->control($control = new ControlAsset)
-            ->trial('trial', new TrialAsset)
+            ->trial('trial', new SideEffectTrialAsset())
             ->blind();
 
         $blind->behavior();
@@ -48,11 +93,56 @@ class StudyTest extends PHPUnit_Framework_TestCase
 
         $blind = $study
             ->control($control = new ControlAsset)
-            ->trial('trial', new TrialAsset)
+            ->trial('trial', new SideEffectTrialAsset)
             ->blind();
 
         $blind->attribute;
 
         $this->assertInstanceOf(MissingProperty::class, $journal->getReport()->getTrial('trial')->getException());
+    }
+
+    public function test_that_a_change_variable_can_be_set()
+    {
+        $study = new Study('test');
+        $study->setChance(3);
+        $this->assertEquals(3, $study->getChance());
+    }
+
+    public function test_that_a_laboratory_can_be_set()
+    {
+        $study = new Study('test');
+        $study->setLaboratory($l = new Laboratory());
+        $this->assertSame($l, $study->getLaboratory());
+    }
+
+    public function test_that_a_matcher_can_be_set()
+    {
+        $study = new Study('test');
+        $study->setMatcher($m = new StandardMatcher());
+        $this->assertSame($m, $study->getMatcher());
+    }
+
+    public function test_that_a_name_can_be_set()
+    {
+        $study = new Study('test');
+        $this->assertEquals('test', $study->getName());
+    }
+
+    public function test_that_an_experiment_can_be_added()
+    {
+        $study = new Study('test');
+        $e = new Experiment('experiment');
+        $study->addExperiment($e);
+        $this->assertSame($e, $study->getExperiment('experiment'));
+        $this->assertEquals(['experiment' => $e], $study->getExperiments());
+    }
+
+    public function test_that_a_trial_can_be_added()
+    {
+        $study = new Study('test');
+        $trial = function(){};
+        $study->trial('trial', $trial);
+        $this->assertSame($trial, $study->getTrial('trial'));
+        $this->assertEquals(['trial' => $trial], $study->getTrials());
     }
 }

--- a/tests/StudyTest.php
+++ b/tests/StudyTest.php
@@ -1,7 +1,10 @@
 <?php
 
 
+use Scientist\Journals\StandardJournal;
 use Scientist\Laboratory;
+use Scientist\SideEffects\MissingMethod;
+use Scientist\SideEffects\MissingProperty;
 use Scientist\Study;
 use Study\ControlAsset;
 use Study\TrialAsset;
@@ -19,34 +22,33 @@ class StudyTest extends PHPUnit_Framework_TestCase
         $this->assertNotSame($control, $blind);
     }
 
-    public function test_study_aggregates_experiment_reports()
-    {
-        $this->markTestIncomplete('todo');
-    }
-
-    /**
-     * @expectedException \Scientist\SideEffects\MissingMethod
-     */
     public function test_study_uncovers_missing_method_side_effects()
     {
-        $blind = (new Study('study', new Laboratory()))
+        $study = new Study('test', new Laboratory());
+        $study->getLaboratory()->addJournal($journal = new StandardJournal());
+
+        $blind = $study
             ->control($control = new ControlAsset)
-            ->trial('trial name', new TrialAsset)
+            ->trial('trial', new TrialAsset)
             ->blind();
 
         $blind->behavior();
+
+        $this->assertInstanceOf(MissingMethod::class, $journal->getReport()->getTrial('trial')->getException());
     }
 
-    /**
-     * @expectedException \Scientist\SideEffects\MissingProperty
-     */
     public function test_study_uncovers_missing_property_side_effects()
     {
-        $blind = (new Study('study', new Laboratory()))
+        $study = new Study('test', new Laboratory());
+        $study->getLaboratory()->addJournal($journal = new StandardJournal());
+
+        $blind = $study
             ->control($control = new ControlAsset)
-            ->trial('trial name', new TrialAsset)
+            ->trial('trial', new TrialAsset)
             ->blind();
 
         $blind->attribute;
+
+        $this->assertInstanceOf(MissingProperty::class, $journal->getReport()->getTrial('trial')->getException());
     }
 }


### PR DESCRIPTION
# Class Experiments

This is a feature addition that adds the abilities to run experiments on classes. 
## Features
- creates a proxy instance that can be used throughout your system
- proxy instance can implement as many interfaces as you need/want (including none) for when you have typehints/no-typehints
- control properties that are used but not implemented in trials are tracked
- control methods that are used but not implemented in trials are tracked
## Use Case

Imagine you have a dependency in your system that you want to write a new implementation for. With class experiments you can create proxy around your dependency so that experiments can be run against trial implementations. 
### usage sample

Provided you have a defined dependency, and a dependency factory:

``` php
interface UserRepository {
    public function getUserComments($userId);
    public function getUserArticles($userId);
    public function getUserKarma($userId);
}

// your existing implementation
class PdoUserRepository implements UserRepository {
    public function __construct(Pdo $db) { }
    // ... method implementations
} 

// your existing factory
class UserRepositoryFactory {
    public function create($di) {
        $db = $di['database'];
        return new PdoUserRepository($db);
    }
}
```

You also have a new user repository implementation:

``` php
class DoctrineUserRepository implements UserRepository {
    public function __construct(EntityManager $em) { }
    // ... method implementations
}
```

In order to run an experiment in your application with the old implementation as control, and new implementation as a trial, you would update your factory like:

``` php
class UserRepositoryFactory {
    public function create($di) {
        $db = $di['database'];
        $em = $di['entity_manager'];
        $scientist = $di['scientist'];
        $blind = $scientist->study('doctrine user repository implementation')
            ->control(new PdoUserRepository($db))
            ->trial(new DoctrineUserRepository($db))
            ->blind(UserRepository::class); // blind will implement UserRepository

           return $blind;
    }
}
```
## Internal Workings

The class experiment is implemented as a collection of experiments created to match each of the public methods and properties of the control instance. A proxy object is created that will map method calls and property access to the appropriate experiment. The proxy object can optionally implement a interface(s) so that it satisfies type hints.

Besides some work under the hood, the feature is functionally equivalent to manually creating an experiment for each method of a class. Ie:

``` php
$control = new Foo;
$trial = new Bar;

$experiment = $scientist->experiment('methodA')
    ->control(function() use($control) { $args = func_get_args(); return call_user_func_array([$control, $args]); })
    ->trial(function() use($trial) { $args = func_get_args(); return call_user_func_array([$trial, $args]); });

$experiment->run(); 
```
