### PR TITLE
[Food for thought] Replace get args with splats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - '5.5'
   - '5.6'
   - '7.0'
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5"
+        "php": "^5.6 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8",

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -243,11 +243,13 @@ class Experiment
     /**
      * Execute the experiment within the laboratory.
      *
+     * @param mixed[] $params
+     *
      * @return mixed
      */
-    public function run()
+    public function run(...$params)
     {
-        $this->params = func_get_args();
+        $this->params = $params;
 
         if ($this->laboratory) {
             return $this->laboratory->runExperiment($this);
@@ -259,11 +261,13 @@ class Experiment
     /**
      * Execute the experiment and return a report.
      *
-     * @return \Scientist\Report
+     * @param mixed[] $params
+     *
+     * @return Report
      */
-    public function report()
+    public function report(...$params)
     {
-        $this->params = func_get_args();
+        $this->params = $params;
 
         return $this->laboratory->getReport($this);
     }


### PR DESCRIPTION
There's a balance here between how many legacy code-bases you're using this for are stuck on 5.5 vs how useful explicit code is.

Thought it might be worth raising the question.
