### PR TITLE
replace php  >= 5.5 with ^5.5 || ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5"
+        "php": "^5.5 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8",


### PR DESCRIPTION
Technically >= 5.5 could cause problems as a php 8.0 with breaking changes would be matched.
