### PR TITLE
Prevents Experiments with a chance of zero from running.

### DIFF
--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -213,7 +213,7 @@ class Experiment
      */
     public function shouldRun()
     {
-        return rand(0, 100) <= $this->chance;
+        return rand(1, 100) <= $this->chance;
     }
 
     /**


### PR DESCRIPTION
In PHP, rand($min, $max) is inclusive of the min and max values.

http://php.net/manual/en/function.rand.php

This should be edited such that experiments with a chance of zero never happen.

It could alternately be solved by changing `<=` to `<`
