### PR TITLE
Add a matcher that uses closures

### DIFF
--- a/src/Matchers/ClosureMatcher.php
+++ b/src/Matchers/ClosureMatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Scientist\Matchers;
+
+/**
+ * Class ClosureMatcher
+ *
+ * @package \Scientist\Matchers
+ */
+class ClosureMatcher implements Matcher
+{
+    /**
+     * A closure which attempts to match the results.
+     * @var \Closure
+     */
+    protected $closure;
+
+    /**
+     * Create a new matcher instance based on a closure.
+     * @param \Closure $closure The closure to use
+     */
+    public function __construct(\Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function match($control, $trial)
+    {
+        return call_user_func($this->closure, $control, $trial);
+    }
+}

--- a/tests/Matchers/ClosureMatcherTest.php
+++ b/tests/Matchers/ClosureMatcherTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Scientist\Matchers\ClosureMatcher;
+
+class ClosureMatcherTest extends PHPUnit_Framework_TestCase
+{
+    private function getClosure()
+    {
+        return function ($control, $trial) {
+            return strtoupper($control) == strtoupper($trial);
+        };
+    }
+
+    public function test_that_closure_matcher_can_be_created()
+    {
+        $matcher = new ClosureMatcher($this->getClosure());
+        $this->assertInstanceOf(ClosureMatcher::class, $matcher);
+    }
+
+    public function test_that_closure_matcher_can_match_values()
+    {
+        $matcher = new ClosureMatcher($this->getClosure());
+        $this->assertTrue($matcher->match('uppercase', 'UpperCase'));
+    }
+
+    public function test_that_closure_matcher_can_fail_to_match_values()
+    {
+        $matcher = new ClosureMatcher($this->getClosure());
+        $this->assertFalse($matcher->match('uppercase', 'LowerCase'));
+    }
+}


### PR DESCRIPTION
I've had a couple of cases where I quickly needed to add a single use matcher so I came up with a matcher class that accepts a closure. I figured it might be useful for other people too so here it is.

One of the cases that I encountered was when trying to determine if I should switch packages. Both packages generated an array of dates that would later be converted into a standard date time string. The place where I wanted to use this package to test out performance was before this conversion was done so it was trying to compare instances of `DateTime` and `DateTimeImmutable` that were also in different timezones. Using the `ClosureMatcher` class I created I was able to do the following:
```php
$experiment->matcher(new ClosureMatcher(function ($control, $trial) {
    return $control->getTimestamp() == $trial->getTimestamp();
}));
```
As you can see this case was pretty specific so it didn't seem to warrant creating a class for something only used in one place.

Tests are included.