### PR TITLE
Require PHPUnit <6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ircmaxell/random-lib": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8",
+        "phpunit/phpunit": ">=4.8,<6",
         "squizlabs/php_codesniffer": "^2.5",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "phing/phing": "^2.13"


### PR DESCRIPTION
In PHPUnit 6 the classes changed to using namespaces.