### PR TITLE
Catch Error Class

### DIFF
--- a/src/Machine.php
+++ b/src/Machine.php
@@ -2,7 +2,7 @@
 
 namespace Scientist;
 
-use Exception;
+use Throwable;
 
 /**
  * Class Executor
@@ -102,7 +102,7 @@ class Machine
     {
         try {
             $this->result->setValue(call_user_func_array($this->callback, $this->params));
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
             $this->result->setException($exception);
             $this->result->setValue(null);
         }

--- a/tests/MachineTest.php
+++ b/tests/MachineTest.php
@@ -52,9 +52,20 @@ class MachineTest extends PHPUnit_Framework_TestCase
         $m->execute();
     }
 
-    public function test_that_machine_can_mute_exceptions_from_callback()
+    public static function getErrorData()
     {
-        $m = new Machine(function () { throw new Exception('foo'); }, [], true);
+        return [
+            [new Exception()],
+            [new Error()],
+        ];
+    }
+
+    /**
+     * @dataProvider getErrorData
+     */
+    public function test_that_machine_can_mute_exceptions_from_callback($exception)
+    {
+        $m = new Machine(function () use ($exception) { throw $exception; }, [], true);
 
         $this->assertEquals(null, $m->execute()->getValue());
     }


### PR DESCRIPTION
Adds catching of the `Error` class (via `Throwable` interface), which indicates internal errors in PHP 7+.  This makes trials more robust to coding errors.