### PR TITLE
Control/Trial Metadata

### DIFF
--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -32,6 +32,13 @@ class Experiment
     protected $control;
 
     /**
+     * Context for the control.
+     *
+     * @var mixed
+     */
+    protected $controlContext;
+
+    /**
      * Trial callbacks.
      *
      * @var array
@@ -104,12 +111,14 @@ class Experiment
      * Register a control callback.
      *
      * @param callable $callback
+     * @param mixed $context
      *
      * @return $this
      */
-    public function control(callable $callback)
+    public function control(callable $callback, $context = null)
     {
         $this->control = $callback;
+        $this->controlContext = $context;
 
         return $this;
     }
@@ -124,6 +133,11 @@ class Experiment
         return $this->control;
     }
 
+    public function getControlContext()
+    {
+        return $this->controlContext;
+    }
+
     /**
      * Register a trial callback.
      *
@@ -132,9 +146,9 @@ class Experiment
      *
      * @return $this
      */
-    public function trial($name, callable $callback)
+    public function trial($name, callable $callback, $context = null)
     {
-        $this->trials[$name] = $callback;
+        $this->trials[$name] = new Trial($name, $callback, $context);
 
         return $this;
     }
@@ -148,7 +162,7 @@ class Experiment
      */
     public function getTrial($name)
     {
-        return $this->trials[$name];
+        return $this->trials[$name]->getCallback();
     }
 
     /**

--- a/src/Intern.php
+++ b/src/Intern.php
@@ -40,7 +40,12 @@ class Intern
      */
     protected function runControl(Experiment $experiment)
     {
-        return (new Machine($experiment->getControl(), $experiment->getParams()))->execute();
+        return (new Machine(
+            $experiment->getControl(),
+            $experiment->getParams(),
+            false,
+            $experiment->getControlContext()
+        ))->execute();
     }
 
     /**
@@ -56,9 +61,10 @@ class Intern
 
         foreach ($experiment->getTrials() as $name => $trial) {
             $executions[$name] = (new Machine(
-                $trial,
+                $trial->getCallback(),
                 $experiment->getParams(),
-                true
+                true,
+                $trial->getContext()
             ))->execute();
         }
 

--- a/src/Machine.php
+++ b/src/Machine.php
@@ -46,12 +46,12 @@ class Machine
      * @param array    $params
      * @param boolean  $muted
      */
-    public function __construct(callable $callback, array $params = [], $muted = false)
+    public function __construct(callable $callback, array $params = [], $muted = false, $context = null)
     {
         $this->callback = $callback;
         $this->params   = $params;
         $this->muted    = $muted;
-        $this->result   = new Result;
+        $this->result   = new Result($context);
     }
 
     /**

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Scientist;
 
 use Exception;
@@ -62,6 +61,16 @@ class Result
      * @var boolean
      */
     protected $match = false;
+
+    /**
+     * @var mixed
+     */
+    protected $context;
+
+    public function __construct($context = null)
+    {
+        $this->context = $context;
+    }
 
     /**
      * Get the callback result value.
@@ -225,6 +234,11 @@ class Result
         $this->exception = $exception;
 
         return $this;
+    }
+
+    public function getContext()
+    {
+        return $this->context;
     }
 
     /**

--- a/src/Trial.php
+++ b/src/Trial.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Scientist;
+
+class Trial
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * @var mixed
+     */
+    protected $context;
+
+    public function __construct($name, callable $callback, $context)
+    {
+        $this->name = $name;
+        $this->callback = $callback;
+        $this->context = $context;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getCallback()
+    {
+        return $this->callback;
+    }
+
+    public function getContext()
+    {
+        return $this->context;
+    }
+}

--- a/tests/ExperimentTest.php
+++ b/tests/ExperimentTest.php
@@ -28,6 +28,25 @@ class ExperimentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($control, $e->getControl());
     }
 
+    public function test_that_control_context_defaults_to_null()
+    {
+        $e = new Experiment('test experiment', new Laboratory);
+        $e->control(function () {
+            return true;
+        });
+        $this->assertNull($e->getControlContext());
+    }
+
+    public function test_that_control_context_can_be_defined()
+    {
+        $context = ['foo' => 'bar'];
+        $e = new Experiment('test experiment', new Laboratory);
+        $e->control(function () {
+            return true;
+        }, $context);
+        $this->assertSame($context, $e->getControlContext());
+    }
+
     public function test_that_a_trial_callback_can_be_defined()
     {
         $e = new Experiment('test experiment', new Laboratory);
@@ -54,11 +73,13 @@ class ExperimentTest extends \PHPUnit\Framework\TestCase
         $e->trial('second', $second);
         $e->trial('third', $third);
         $expected = [
-            'first'  => $first,
-            'second' => $second,
-            'third'  => $third
+            'first',
+            'second',
+            'third',
         ];
-        $this->assertSame($expected, $e->getTrials());
+        $trials = $e->getTrials();
+        $this->assertSame($expected, \array_keys($trials));
+        $this->assertContainsOnlyInstancesOf(\Scientist\Trial::class, $trials);
     }
 
     public function test_that_a_chance_variable_can_be_set()

--- a/tests/MachineTest.php
+++ b/tests/MachineTest.php
@@ -8,7 +8,7 @@ class MachineTest extends \PHPUnit\Framework\TestCase
     public function test_that_machine_can_be_created()
     {
         $m = new Machine(function () {});
-            
+
         $this->assertInstanceOf(Machine::class, $m);
     }
 
@@ -38,6 +38,15 @@ class MachineTest extends \PHPUnit\Framework\TestCase
         $m = new Machine(function () { return 'foo'; });
 
         $this->assertEquals('foo', $m->execute()->getValue());
+    }
+
+    public function test_that_machine_sets_context_result()
+    {
+        $context = ['foo' => 'bar'];
+
+        $m = new Machine(function () { return 'foo'; }, [], true, $context);
+
+        $this->assertSame($context, $m->execute()->getContext());
     }
 
     public function test_that_machine_executes_callback_with_parameters()

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -7,7 +7,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     public function test_result_can_be_created()
     {
         $r = new Result;
-        
+
         $this->assertInstanceOf(Result::class, $r);
     }
 
@@ -58,6 +58,14 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $r = new Result;
         $r->setMatch(true);
         $this->assertTrue(true, $r->isMatch());
+    }
+
+    public function test_can_have_context()
+    {
+        $context = ['foo' => 'bar'];
+
+        $r = new Result($context);
+        $this->assertSame($context, $r->getContext());
     }
 
     public function test_result_can_have_total_execution_time()


### PR DESCRIPTION
Adds the ability to set "metadata" (a `mixed` var) as a new parameter to `control` and `trial`. This is then available via the `Result` for each.

The use case is that when reporting the results of controls/trials it can be useful to attach metadata to explain/debug the value.

I'm not familiar with the style of the project, but have tried to follow existing conventions with regards code formatting and tests.