### PR TITLE
Fix: Remove dev option when installing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ matrix:
   allow_failures:
     - php: nightly
 install:
-  - composer install --dev
+  - composer install
 script: vendor/bin/phing


### PR DESCRIPTION
This PR

* [x] removes the `—dev` option when installing dependencies on Travis with composer

💁‍♂️ It’s the default, see https://getcomposer.org/doc/03-cli.md#install:

> ### Options
>
> * **—dev:** Install packages listed in `require-dev` (this is the default behavior).