### PR TITLE
Fix: Do not attempt to return void

### DIFF
--- a/src/Machine.php
+++ b/src/Machine.php
@@ -87,7 +87,9 @@ class Machine
     protected function executeCallback()
     {
         if ($this->muted) {
-            return $this->executeMutedCallback();
+            $this->executeMutedCallback();
+            
+            return;
         }
 
         $this->result->setValue(call_user_func_array($this->callback, $this->params));


### PR DESCRIPTION
This PR

* [x] splits a statement which would otherwise attempt to return a `void` return value