### PR TITLE
Allow control and trials to use different arguments

### DIFF
--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -39,6 +39,13 @@ class Experiment
     protected $controlContext;
 
     /**
+     * Arguments for the control.
+     *
+     * @var mixed
+     */
+    protected $controlArguments;
+
+    /**
      * Trial callbacks.
      *
      * @var array
@@ -115,10 +122,11 @@ class Experiment
      *
      * @return $this
      */
-    public function control(callable $callback, $context = null)
+    public function control(callable $callback, $context = null, $arguments = [])
     {
         $this->control = $callback;
         $this->controlContext = $context;
+        $this->controlArguments = $arguments;
 
         return $this;
     }
@@ -139,6 +147,16 @@ class Experiment
     }
 
     /**
+     * Fetch the arguments to use with the control callback.
+     *
+     * @return array
+     */
+    public function getControlArguments(): array
+    {
+        return $this->controlArguments;
+    }
+
+    /**
      * Register a trial callback.
      *
      * @param string   $name
@@ -146,9 +164,9 @@ class Experiment
      *
      * @return $this
      */
-    public function trial($name, callable $callback, $context = null)
+    public function trial($name, callable $callback, $context = null, $arguments = [])
     {
-        $this->trials[$name] = new Trial($name, $callback, $context);
+        $this->trials[$name] = new Trial($name, $callback, $context, $arguments);
 
         return $this;
     }

--- a/src/Intern.php
+++ b/src/Intern.php
@@ -40,9 +40,15 @@ class Intern
      */
     protected function runControl(Experiment $experiment)
     {
+        $argParams = $experiment->getParams();
+
+        if (!empty($experiment->getControlArguments())) {
+            $argParams = $experiment->getControlArguments();
+        }
+
         return (new Machine(
             $experiment->getControl(),
-            $experiment->getParams(),
+            $argParams,
             false,
             $experiment->getControlContext()
         ))->execute();
@@ -60,9 +66,15 @@ class Intern
         $executions = [];
 
         foreach ($experiment->getTrials() as $name => $trial) {
+            $trialArgs = $experiment->getParams();
+
+            if (!empty($trial->getArguments())) {
+                $trialArgs = $trial->getArguments();
+            }
+
             $executions[$name] = (new Machine(
                 $trial->getCallback(),
-                $experiment->getParams(),
+                $trialArgs,
                 true,
                 $trial->getContext()
             ))->execute();

--- a/src/Trial.php
+++ b/src/Trial.php
@@ -19,11 +19,17 @@ class Trial
      */
     protected $context;
 
-    public function __construct($name, callable $callback, $context)
+    /**
+     * @var array
+     */
+    protected $arguments = [];
+
+    public function __construct($name, callable $callback, $context, array $arguments = [])
     {
         $this->name = $name;
         $this->callback = $callback;
         $this->context = $context;
+        $this->arguments = $arguments;
     }
 
     public function getName()
@@ -39,5 +45,10 @@ class Trial
     public function getContext()
     {
         return $this->context;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
     }
 }

--- a/tests/ExperimentTest.php
+++ b/tests/ExperimentTest.php
@@ -57,6 +57,18 @@ class ExperimentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($trial, $e->getTrial('trial'));
     }
 
+    public function test_that_a_trial_callback_with_different_arguments_can_be_defined()
+    {
+        $e = new Experiment('test experiment', new Laboratory);
+        $trialArgs = ['input' => 'some_string'];
+        $trial = function ($input) {
+            return $input;
+        };
+        $e->trial('my_trial', $trial, null, $trialArgs);
+        $this->assertSame($trial, $e->getTrial('my_trial'));
+        $this->assertSame($e->getTrials()['my_trial']->getArguments(), $trialArgs);
+    }
+
     public function test_that_multiple_trial_callbacks_can_be_defined()
     {
         $e = new Experiment('test experiment', new Laboratory);

--- a/tests/InternTest.php
+++ b/tests/InternTest.php
@@ -57,4 +57,17 @@ class InternTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($v->getTrial('bar')->isMatch());
         $this->assertFalse($v->getTrial('baz')->isMatch());
     }
+
+    public function test_that_intern_can_control_and_trial_with_different_arguments()
+    {
+        $i = new Intern;
+        $e = new Experiment('test experiment', new Laboratory);
+        $e->control(function ($input) { return $input; }, null, ['my_var' => 1]);
+        $e->trial('bar', function ($input) { return $input*2; }, null, ['my_var' => 2]);
+        $v = $i->run($e);
+        $this->assertInstanceOf(Report::class, $v);
+        $this->assertFalse($v->getTrial('bar')->isMatch());
+        $this->assertEquals(1, $v->getControl()->getValue());
+        $this->assertEquals(4, $v->getTrial('bar')->getValue());
+    }
 }


### PR DESCRIPTION
Allow for control and trial callbacks to use different method signatures to add more flexibility when refactoring code.