### PR TITLE
Enable lean releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+build.xml export-ignore
+CHANGELOG.md export-ignore
+CONTRIBUTING.md export-ignore
+phpunit.xml export-ignore
+README.md export-ignore
+tests/ export-ignore


### PR DESCRIPTION
By utilising [.gitattributes](https://hannesvdvreken.com/2015/01/14/gitattributes/), repository artifacts which are not relevant for the actual framework usage are exluded.