### PR TITLE
Update code for PHP 7.3 or greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,22 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": ">=7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "squizlabs/php_codesniffer": "^2.5",
-        "jakub-onderka/php-parallel-lint": "^0.9.2",
+        "phpunit/phpunit": "^9.5",
+        "squizlabs/php_codesniffer": "^2.9",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "phing/phing": "^2.13"
     },
     "autoload": {
         "psr-4": {
             "Scientist\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Scientist\\Tests\\": "tests"
         }
     }
 }


### PR DESCRIPTION
- Add namespaces to tests
- Add use statements
- Update PHPUnit to 9.5
- replace assertInternalType with assertIsFloat,assertIsInt,assertNull
for PHPUnit 9.5
- change return on \Scientist\Machine::executeCallback to not return the
 result of a void method, and return afterwards
- update rand calls to random_int
- update return type on StandardChanceTest setup() to match TestCase
- remove mixed phpDoc on StandardJournal report that does not return
anything
- set minimum PHP to 7.3
- update composer.json
- replace abandoned php-parallel-lint with newer package