### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,7 +21,7 @@ jobs:
     name: PHP ${{ matrix.php }} tests
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # see https://github.com/shivammathur/setup-php
       - uses: shivammathur/setup-php@v2


### PR DESCRIPTION
- I missed the warning messages about v2 being out of date when I created/copied the github actions