### PR TITLE
Better explain the code using actual type hints

### DIFF
--- a/src/Chances/Chance.php
+++ b/src/Chances/Chance.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Scientist\Chances;
 
 interface Chance

--- a/src/Chances/Chance.php
+++ b/src/Chances/Chance.php
@@ -3,5 +3,5 @@ namespace Scientist\Chances;
 
 interface Chance
 {
-    public function shouldRun();
+    public function shouldRun(): bool;
 }

--- a/src/Chances/StandardChance.php
+++ b/src/Chances/StandardChance.php
@@ -3,6 +3,9 @@ namespace Scientist\Chances;
 
 class StandardChance implements Chance
 {
+    /**
+     * @var int
+     */
     private $percentage = 100;
 
     /**

--- a/src/Chances/StandardChance.php
+++ b/src/Chances/StandardChance.php
@@ -8,7 +8,7 @@ class StandardChance implements Chance
     /**
      * Determine whether or not the experiment should run
      */
-    public function shouldRun()
+    public function shouldRun(): bool
     {
         if ($this->percentage == 0) {
             return false;
@@ -19,19 +19,12 @@ class StandardChance implements Chance
         return $random <= $this->percentage;
     }
 
-    /**
-     * @return int
-     */
-    public function getPercentage()
+    public function getPercentage(): int
     {
         return $this->percentage;
     }
 
-    /**
-     * @param int $percentage
-     * @return $this
-     */
-    public function setPercentage($percentage)
+    public function setPercentage(int $percentage): self
     {
         $this->percentage = $percentage;
         

--- a/src/Chances/StandardChance.php
+++ b/src/Chances/StandardChance.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Scientist\Chances;
 
 class StandardChance implements Chance

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -42,7 +42,7 @@ class Experiment
     /**
      * Trial callbacks.
      *
-     * @var array
+     * @var callable[]
      */
     protected $trials = [];
 
@@ -122,6 +122,9 @@ class Experiment
         return $this->control;
     }
 
+    /**
+     * @return mixed
+     */
     public function getControlContext()
     {
         return $this->controlContext;
@@ -129,6 +132,8 @@ class Experiment
 
     /**
      * Register a trial callback.
+     *
+     * @param mixed $context
      */
     public function trial(string $name, callable $callback, $context = null): self
     {
@@ -147,6 +152,8 @@ class Experiment
 
     /**
      * Fetch an array of trial callbacks.
+     *
+     * @return callable[]
      */
     public function getTrials(): array
     {

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -139,10 +139,8 @@ class Experiment
 
     /**
      * Fetch a trial callback by name.
-     * 
-     * @return mixed
      */
-    public function getTrial(string $name)
+    public function getTrial(string $name): callable
     {
         return $this->trials[$name]->getCallback();
     }

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -2,6 +2,7 @@
 
 namespace Scientist;
 
+use Scientist\Report;
 use Scientist\Chances\Chance;
 use Scientist\Chances\StandardChance;
 use Scientist\Matchers\Matcher;
@@ -75,11 +76,8 @@ class Experiment
 
     /**
      * Create a new experiment.
-     *
-     * @param string                $name
-     * @param \Scientist\Laboratory $laboratory
      */
-    public function __construct($name, Laboratory $laboratory)
+    public function __construct(string $name, Laboratory $laboratory)
     {
         $this->name = $name;
         $this->laboratory = $laboratory;
@@ -89,20 +87,16 @@ class Experiment
 
     /**
      * Fetch the experiment name.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
      * Retrieve the laboratory instance.
-     *
-     * @return \Scientist\Laboratory|null
      */
-    public function getLaboratory()
+    public function getLaboratory(): ?Laboratory
     {
         return $this->laboratory;
     }
@@ -110,12 +104,9 @@ class Experiment
     /**
      * Register a control callback.
      *
-     * @param callable $callback
      * @param mixed $context
-     *
-     * @return $this
      */
-    public function control(callable $callback, $context = null)
+    public function control(callable $callback, $context = null): self
     {
         $this->control = $callback;
         $this->controlContext = $context;
@@ -125,10 +116,8 @@ class Experiment
 
     /**
      * Fetch the control callback.
-     *
-     * @return callable
      */
-    public function getControl()
+    public function getControl(): callable
     {
         return $this->control;
     }
@@ -140,13 +129,8 @@ class Experiment
 
     /**
      * Register a trial callback.
-     *
-     * @param string   $name
-     * @param callable $callback
-     *
-     * @return $this
      */
-    public function trial($name, callable $callback, $context = null)
+    public function trial(string $name, callable $callback, $context = null): self
     {
         $this->trials[$name] = new Trial($name, $callback, $context);
 
@@ -155,34 +139,26 @@ class Experiment
 
     /**
      * Fetch a trial callback by name.
-     *
-     * @param string $name
-     *
+     * 
      * @return mixed
      */
-    public function getTrial($name)
+    public function getTrial(string $name)
     {
         return $this->trials[$name]->getCallback();
     }
 
     /**
      * Fetch an array of trial callbacks.
-     *
-     * @return array
      */
-    public function getTrials()
+    public function getTrials(): array
     {
         return $this->trials;
     }
 
     /**
      * Set a matcher for this experiment.
-     *
-     * @param \Scientist\Matchers\Matcher $matcher
-     *
-     * @return $this
      */
-    public function matcher(Matcher $matcher)
+    public function matcher(Matcher $matcher): self
     {
         $this->matcher = $matcher;
 
@@ -191,22 +167,16 @@ class Experiment
 
     /**
      * Get the matcher for this experiment.
-     *
-     * @return \Scientist\Matchers\Matcher
      */
-    public function getMatcher()
+    public function getMatcher(): Matcher
     {
         return $this->matcher;
     }
 
     /**
      * Set the execution chance.
-     *
-     * @param Chances\Chance $chance
-     *
-     * @return $this
      */
-    public function chance(Chance $chance)
+    public function chance(Chance $chance): self
     {
         $this->chance = $chance;
 
@@ -215,20 +185,16 @@ class Experiment
 
     /**
      * Get the execution chance.
-     *
-     * @return Chances\Chance
      */
-    public function getChance()
+    public function getChance(): Chance
     {
         return $this->chance;
     }
 
     /**
      * Determine whether an experiment should run based on chance.
-     *
-     * @return boolean
      */
-    public function shouldRun()
+    public function shouldRun(): bool
     {
         return $this->chance
             ->shouldRun();
@@ -236,10 +202,8 @@ class Experiment
 
     /**
      * Get the experiment parameters.
-     *
-     * @return array
      */
-    public function getParams()
+    public function getParams(): array
     {
         return $this->params;
     }
@@ -258,10 +222,8 @@ class Experiment
 
     /**
      * Execute the experiment and return a report.
-     *
-     * @return \Scientist\Report
      */
-    public function report()
+    public function report(): Report
     {
         $this->params = func_get_args();
 

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist;
 

--- a/src/Intern.php
+++ b/src/Intern.php
@@ -16,12 +16,8 @@ class Intern
 {
     /**
      * Run an experiment, and retrieve the result.
-     *
-     * @param \Scientist\Experiment $experiment
-     *
-     * @return \Scientist\Report
      */
-    public function run(Experiment $experiment)
+    public function run(Experiment $experiment): Report
     {
         $control = $this->runControl($experiment);
         $trials  = $this->runTrials($experiment);
@@ -33,12 +29,8 @@ class Intern
 
     /**
      * Run the control callback, and record its execution state.
-     *
-     * @param \Scientist\Experiment $experiment
-     *
-     * @return \Scientist\Result
      */
-    protected function runControl(Experiment $experiment)
+    protected function runControl(Experiment $experiment): Result
     {
         return (new Machine(
             $experiment->getControl(),
@@ -51,11 +43,9 @@ class Intern
     /**
      * Run trial callbacks and record their execution state.
      *
-     * @param \Scientist\Experiment $experiment
-     *
-     * @return \Scientist\Result[]
+     * @return Result[]
      */
-    protected function runTrials(Experiment $experiment)
+    protected function runTrials(Experiment $experiment): array
     {
         $executions = [];
 
@@ -74,11 +64,9 @@ class Intern
     /**
      * Determine whether trial results match the control.
      *
-     * @param \Scientist\Matchers\Matcher $matcher
-     * @param \Scientist\Result           $control
-     * @param \Scientist\Result[]         $trials
+     * @param Result[] $trials
      */
-    protected function determineMatches(Matcher $matcher, Result $control, array $trials = [])
+    protected function determineMatches(Matcher $matcher, Result $control, array $trials = []): void
     {
         foreach ($trials as $trial) {
             if ($matcher->match($control->getValue(), $trial->getValue())) {

--- a/src/Intern.php
+++ b/src/Intern.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist;
 

--- a/src/Journals/Journal.php
+++ b/src/Journals/Journal.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist\Journals;
 

--- a/src/Journals/Journal.php
+++ b/src/Journals/Journal.php
@@ -18,9 +18,6 @@ interface Journal
     /**
      * Dispatch a report to storage.
      *
-     * @param \Scientist\Experiment $experiment
-     * @param \Scientist\Report     $report
-     *
      * @return mixed
      */
     public function report(Experiment $experiment, Report $report);

--- a/src/Journals/StandardJournal.php
+++ b/src/Journals/StandardJournal.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist\Journals;
 

--- a/src/Journals/StandardJournal.php
+++ b/src/Journals/StandardJournal.php
@@ -42,20 +42,16 @@ class StandardJournal implements Journal
 
     /**
      * Get the experiment.
-     *
-     * @return \Scientist\Experiment
      */
-    public function getExperiment()
+    public function getExperiment(): Experiment
     {
         return $this->experiment;
     }
 
     /**
      * Get the experiment report.
-     *
-     * @return \Scientist\Report
      */
-    public function getReport()
+    public function getReport(): Report
     {
         return $this->report;
     }

--- a/src/Journals/StandardJournal.php
+++ b/src/Journals/StandardJournal.php
@@ -31,10 +31,8 @@ class StandardJournal implements Journal
      *
      * @param \Scientist\Experiment $experiment
      * @param \Scientist\Report     $report
-     *
-     * @return mixed
      */
-    public function report(Experiment $experiment, Report $report)
+    public function report(Experiment $experiment, Report $report): void
     {
         $this->experiment = $experiment;
         $this->report     = $report;

--- a/src/Journals/StandardJournal.php
+++ b/src/Journals/StandardJournal.php
@@ -15,22 +15,19 @@ class StandardJournal implements Journal
     /**
      * The executed experiment.
      *
-     * @var \Scientist\Experiment
+     * @var Experiment
      */
     protected $experiment;
 
     /**
      * The experiment report.
      *
-     * @var \Scientist\Report
+     * @var Report
      */
     protected $report;
 
     /**
      * Dispatch a report to storage.
-     *
-     * @param \Scientist\Experiment $experiment
-     * @param \Scientist\Report     $report
      */
     public function report(Experiment $experiment, Report $report): void
     {

--- a/src/Laboratory.php
+++ b/src/Laboratory.php
@@ -24,11 +24,9 @@ class Laboratory
     /**
      * Register a collection of journals.
      *
-     * @param array $journals
-     *
-     * @return $this
+     * @param Journal[] $journals
      */
-    public function setJournals(array $journals = [])
+    public function setJournals(array $journals = []): self
     {
         $this->journals = [];
         foreach ($journals as $journal) {
@@ -40,12 +38,8 @@ class Laboratory
 
     /**
      * Register a new journal.
-     *
-     * @param \Scientist\Journals\Journal $journal
-     *
-     * @return $this
      */
-    public function addJournal(Journal $journal)
+    public function addJournal(Journal $journal): self
     {
         $this->journals[] = $journal;
 
@@ -55,9 +49,9 @@ class Laboratory
     /**
      * Retrieve registers journals.
      *
-     * @return array
+     * @return Journal[]
      */
-    public function getJournals()
+    public function getJournals(): array
     {
         return $this->journals;
     }
@@ -65,11 +59,9 @@ class Laboratory
     /**
      * Start a new experiment.
      *
-     * @param string $name
-     *
      * @return mixed
      */
-    public function experiment($name)
+    public function experiment(string $name)
     {
         return (new Experiment($name, $this));
     }
@@ -96,12 +88,8 @@ class Laboratory
 
     /**
      * Run an experiment and return the result.
-     *
-     * @param \Scientist\Experiment $experiment
-     *
-     * @return \Scientist\Report
      */
-    public function getReport(Experiment $experiment)
+    public function getReport(Experiment $experiment): Report
     {
         $report = (new Intern)->run($experiment);
         $this->reportToJournals($experiment, $report);
@@ -111,13 +99,8 @@ class Laboratory
 
     /**
      * Report experiment result to registered journals.
-     *
-     * @param \Scientist\Experiment $experiment
-     * @param \Scientist\Report     $report
-     *
-     * @return void
      */
-    protected function reportToJournals(Experiment $experiment, Report $report)
+    protected function reportToJournals(Experiment $experiment, Report $report): void
     {
         foreach ($this->journals as $journal) {
             $journal->report($experiment, $report);

--- a/src/Laboratory.php
+++ b/src/Laboratory.php
@@ -69,8 +69,6 @@ class Laboratory
     /**
      * Run an experiment.
      *
-     * @param \Scientist\Experiment $experiment
-     *
      * @return mixed
      */
     public function runExperiment(Experiment $experiment)

--- a/src/Laboratory.php
+++ b/src/Laboratory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist;
 

--- a/src/Machine.php
+++ b/src/Machine.php
@@ -80,7 +80,8 @@ class Machine
     protected function executeCallback(): void
     {
         if ($this->muted) {
-            return $this->executeMutedCallback();
+            $this->executeMutedCallback();
+            return;
         }
 
         $this->result->setValue(call_user_func_array($this->callback, $this->params));

--- a/src/Machine.php
+++ b/src/Machine.php
@@ -28,7 +28,7 @@ class Machine
     /**
      * Should exceptions be muted.
      *
-     * @var boolean
+     * @var bool
      */
     protected $muted = false;
 
@@ -42,6 +42,7 @@ class Machine
     /**
      * Inject machine dependencies.
      *
+     * @param mixed $context
      */
     public function __construct(callable $callback, array $params = [], bool $muted = false, $context = null)
     {
@@ -91,7 +92,7 @@ class Machine
     {
         try {
             $this->result->setValue(call_user_func_array($this->callback, $this->params));
-        } catch (Throwable $exception) {
+        } catch (\Throwable $exception) {
             $this->result->setException($exception);
             $this->result->setValue(null);
         }

--- a/src/Machine.php
+++ b/src/Machine.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist;
 

--- a/src/Machine.php
+++ b/src/Machine.php
@@ -42,11 +42,8 @@ class Machine
     /**
      * Inject machine dependencies.
      *
-     * @param callable $callback
-     * @param array    $params
-     * @param boolean  $muted
      */
-    public function __construct(callable $callback, array $params = [], $muted = false, $context = null)
+    public function __construct(callable $callback, array $params = [], bool $muted = false, $context = null)
     {
         $this->callback = $callback;
         $this->params   = $params;
@@ -56,10 +53,8 @@ class Machine
 
     /**
      * Execute the callback and retrieve a result.
-     *
-     * @return \Scientist\Result
      */
-    public function execute()
+    public function execute(): Result
     {
         $this->setStartValues();
         $this->executeCallback();
@@ -70,10 +65,8 @@ class Machine
 
     /**
      * Set values before callback is executed.
-     *
-     * @return void
      */
-    protected function setStartValues()
+    protected function setStartValues(): void
     {
         $this->result->setStartTime(microtime(true));
         $this->result->setStartMemory(memory_get_usage());
@@ -81,10 +74,8 @@ class Machine
 
     /**
      * Execute the callback with parameters.
-     *
-     * @return void
      */
-    protected function executeCallback()
+    protected function executeCallback(): void
     {
         if ($this->muted) {
             return $this->executeMutedCallback();
@@ -95,10 +86,8 @@ class Machine
 
     /**
      * Execute the callback, but swallow exceptions.
-     *
-     * @return void
      */
-    protected function executeMutedCallback()
+    protected function executeMutedCallback(): void
     {
         try {
             $this->result->setValue(call_user_func_array($this->callback, $this->params));
@@ -110,10 +99,8 @@ class Machine
 
     /**
      * Set values after the callback has executed.
-     *
-     * @return void
      */
-    protected function setEndValues()
+    protected function setEndValues(): void
     {
         $this->result->setEndTime(microtime(true));
         $this->result->setEndMemory(memory_get_usage());

--- a/src/Matchers/ClosureMatcher.php
+++ b/src/Matchers/ClosureMatcher.php
@@ -17,7 +17,6 @@ class ClosureMatcher implements Matcher
 
     /**
      * Create a new matcher instance based on a closure.
-     * @param \Closure $closure The closure to use
      */
     public function __construct(\Closure $closure)
     {

--- a/src/Matchers/ClosureMatcher.php
+++ b/src/Matchers/ClosureMatcher.php
@@ -27,7 +27,7 @@ class ClosureMatcher implements Matcher
     /**
      * @inheritDoc
      */
-    public function match($control, $trial)
+    public function match($control, $trial): bool
     {
         return call_user_func($this->closure, $control, $trial);
     }

--- a/src/Matchers/ClosureMatcher.php
+++ b/src/Matchers/ClosureMatcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist\Matchers;
 

--- a/src/Matchers/Matcher.php
+++ b/src/Matchers/Matcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist\Matchers;
 

--- a/src/Matchers/Matcher.php
+++ b/src/Matchers/Matcher.php
@@ -16,8 +16,6 @@ interface Matcher
      *
      * @param mixed $control
      * @param mixed $trial
-     *
-     * @return boolean
      */
-    public function match($control, $trial);
+    public function match($control, $trial): bool;
 }

--- a/src/Matchers/StandardMatcher.php
+++ b/src/Matchers/StandardMatcher.php
@@ -14,10 +14,8 @@ class StandardMatcher implements Matcher
      *
      * @param mixed $control
      * @param mixed $trial
-     *
-     * @return boolean
      */
-    public function match($control, $trial)
+    public function match($control, $trial): bool
     {
         return $control === $trial;
     }

--- a/src/Matchers/StandardMatcher.php
+++ b/src/Matchers/StandardMatcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist\Matchers;
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist;
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -35,12 +35,8 @@ class Report
 
     /**
      * Create a new result instance.
-     *
-     * @param string            $name
-     * @param \Scientist\Result $control
-     * @param array             $trials
      */
-    public function __construct($name, Result $control, array $trials = [])
+    public function __construct(string $name, Result $control, array $trials = [])
     {
         $this->name    = $name;
         $this->control = $control;
@@ -49,32 +45,24 @@ class Report
 
     /**
      * Get the experiment name.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
      * Get the control result instance.
-     *
-     * @return \Scientist\Result
      */
-    public function getControl()
+    public function getControl(): Result
     {
         return $this->control;
     }
 
     /**
      * Get a trial result instance by name.
-     *
-     * @param string $name
-     *
-     * @return \Scientist\Result
      */
-    public function getTrial($name)
+    public function getTrial(string $name): Result
     {
         return $this->trials[$name];
     }
@@ -82,9 +70,9 @@ class Report
     /**
      * Get the trial result instances.
      *
-     * @return array
+     * @return Result[]
      */
-    public function getTrials()
+    public function getTrials(): array
     {
         return $this->trials;
     }

--- a/src/Report.php
+++ b/src/Report.php
@@ -29,7 +29,7 @@ class Report
     /**
      * The trial results.
      *
-     * @var array
+     * @var Result[]
      */
     protected $trials = [];
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -185,7 +185,7 @@ class Result
     /**
      * Get the exception thrown by the callback.
      */
-    public function getException(): ?Exception
+    public function getException(): ?\Throwable
     {
         return $this->exception;
     }
@@ -193,7 +193,7 @@ class Result
     /**
      * Set the exception thrown by the callback.
      */
-    public function setException(?Exception $exception): self
+    public function setException(?\Throwable $exception): self
     {
         $this->exception = $exception;
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -58,7 +58,7 @@ class Result
     /**
      * Does the callback result value match the control.
      *
-     * @var boolean
+     * @var bool
      */
     protected $match = false;
 
@@ -67,6 +67,9 @@ class Result
      */
     protected $context;
 
+    /**
+     * @param ?mixed $context
+     */
     public function __construct($context = null)
     {
         $this->context = $context;
@@ -200,6 +203,9 @@ class Result
         return $this;
     }
 
+    /**
+     * @return mixed
+     */
     public function getContext()
     {
         return $this->context;

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Scientist;
 
 use Exception;

--- a/src/Result.php
+++ b/src/Result.php
@@ -86,10 +86,8 @@ class Result
      * Set the callback result value.
      *
      * @param mixed $value
-     *
-     * @return $this
      */
-    public function setValue($value)
+    public function setValue($value): self
     {
         $this->value = $value;
 
@@ -98,22 +96,16 @@ class Result
 
     /**
      * Get the callback execution start time.
-     *
-     * @return float
      */
-    public function getStartTime()
+    public function getStartTime(): float
     {
         return $this->startTime;
     }
 
     /**
      * Set the callback execution start time.
-     *
-     * @param float $startTime
-     *
-     * @return $this
      */
-    public function setStartTime($startTime)
+    public function setStartTime(float $startTime): self
     {
         $this->startTime = $startTime;
 
@@ -122,22 +114,16 @@ class Result
 
     /**
      * Get the callback execution end time.
-     *
-     * @return float
      */
-    public function getEndTime()
+    public function getEndTime(): float
     {
         return $this->endTime;
     }
 
     /**
      * Set the callback execution end time.
-     *
-     * @param float $endTime
-     *
-     * @return $this
      */
-    public function setEndTime($endTime)
+    public function setEndTime(float $endTime): self
     {
         $this->endTime = $endTime;
 
@@ -146,32 +132,24 @@ class Result
 
     /**
      * Get the execution time of the callback.
-     *
-     * @return float
      */
-    public function getTime()
+    public function getTime(): float
     {
         return $this->endTime - $this->startTime;
     }
 
     /**
      * Get the callback execution starting memory usage.
-     *
-     * @return float
      */
-    public function getStartMemory()
+    public function getStartMemory(): float
     {
         return $this->startMemory;
     }
 
     /**
      * Set the callback execution starting memory usage.
-     *
-     * @param float $startMemory
-     *
-     * @return $this
      */
-    public function setStartMemory($startMemory)
+    public function setStartMemory(float $startMemory): self
     {
         $this->startMemory = $startMemory;
 
@@ -180,22 +158,16 @@ class Result
 
     /**
      * Get the callback execution ending memory usage.
-     *
-     * @return float
      */
-    public function getEndMemory()
+    public function getEndMemory(): float
     {
         return $this->endMemory;
     }
 
     /**
      * Set the callback execution ending memory usage.
-     *
-     * @param float $endMemory
-     *
-     * @return $this
      */
-    public function setEndMemory($endMemory)
+    public function setEndMemory(float $endMemory): self
     {
         $this->endMemory = $endMemory;
 
@@ -204,32 +176,24 @@ class Result
 
     /**
      * Get the memory spike amount of the callback.
-     *
-     * @return float
      */
-    public function getMemory()
+    public function getMemory(): float
     {
         return $this->endMemory - $this->startMemory;
     }
 
     /**
      * Get the exception thrown by the callback.
-     *
-     * @return Exception|null
      */
-    public function getException()
+    public function getException(): ?Exception
     {
         return $this->exception;
     }
 
     /**
      * Set the exception thrown by the callback.
-     *
-     * @param Exception|null $exception
-     *
-     * @return $this
      */
-    public function setException($exception)
+    public function setException(?Exception $exception): self
     {
         $this->exception = $exception;
 
@@ -243,22 +207,16 @@ class Result
 
     /**
      * Determine whether the callback result matches the control.
-     *
-     * @return boolean
      */
-    public function isMatch()
+    public function isMatch(): bool
     {
         return $this->match;
     }
 
     /**
      * Set whether the callback result matches the control.
-     *
-     * @param boolean $match
-     *
-     * @return $this
      */
-    public function setMatch($match)
+    public function setMatch(bool $match): self
     {
         $this->match = $match;
 

--- a/src/Trial.php
+++ b/src/Trial.php
@@ -19,6 +19,9 @@ class Trial
      */
     protected $context;
 
+    /**
+     * @param mixed $context
+     */
     public function __construct(string $name, callable $callback, $context)
     {
         $this->name = $name;
@@ -36,6 +39,9 @@ class Trial
         return $this->callback;
     }
 
+    /**
+     * @return mixed
+     */
     public function getContext()
     {
         return $this->context;

--- a/src/Trial.php
+++ b/src/Trial.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Scientist;
 

--- a/src/Trial.php
+++ b/src/Trial.php
@@ -19,19 +19,19 @@ class Trial
      */
     protected $context;
 
-    public function __construct($name, callable $callback, $context)
+    public function __construct(string $name, callable $callback, $context)
     {
         $this->name = $name;
         $this->callback = $callback;
         $this->context = $context;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getCallback()
+    public function getCallback(): callable
     {
         return $this->callback;
     }

--- a/tests/Chances/StandardChanceTest.php
+++ b/tests/Chances/StandardChanceTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Scientist\Chances;
 
 class StandardChanceTest extends \PHPUnit\Framework\TestCase

--- a/tests/ExperimentTest.php
+++ b/tests/ExperimentTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Experiment;
 use Scientist\Laboratory;

--- a/tests/InternTest.php
+++ b/tests/InternTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Intern;
 use Scientist\Report;

--- a/tests/Journals/JournalTest.php
+++ b/tests/Journals/JournalTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Report;
 use Scientist\Laboratory;

--- a/tests/LaboratoryTest.php
+++ b/tests/LaboratoryTest.php
@@ -39,12 +39,12 @@ class LaboratoryTest extends \PHPUnit\Framework\TestCase
         $this->assertIsFloat($r->getTrial('trial')->getStartTime());
         $this->assertIsFloat($r->getTrial('trial')->getEndTime());
         $this->assertIsFloat($r->getTrial('trial')->getTime());
-        $this->assertIsInt($r->getControl()->getStartMemory());
-        $this->assertIsInt($r->getControl()->getEndMemory());
-        $this->assertIsInt($r->getControl()->getMemory());
-        $this->assertIsInt($r->getTrial('trial')->getStartMemory());
-        $this->assertIsInt($r->getTrial('trial')->getEndMemory());
-        $this->assertIsInt($r->getTrial('trial')->getMemory());
+        $this->assertIsFloat($r->getControl()->getStartMemory());
+        $this->assertIsFloat($r->getControl()->getEndMemory());
+        $this->assertIsFloat($r->getControl()->getMemory());
+        $this->assertIsFloat($r->getTrial('trial')->getStartMemory());
+        $this->assertIsFloat($r->getTrial('trial')->getEndMemory());
+        $this->assertIsFloat($r->getTrial('trial')->getMemory());
         $this->assertNull($r->getControl()->getException());
         $this->assertNull($r->getTrial('trial')->getException());
         $this->assertFalse($r->getTrial('trial')->isMatch());

--- a/tests/LaboratoryTest.php
+++ b/tests/LaboratoryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Report;
 use Scientist\Laboratory;

--- a/tests/MachineTest.php
+++ b/tests/MachineTest.php
@@ -107,7 +107,7 @@ class MachineTest extends \PHPUnit\Framework\TestCase
 
         $r = $m->execute();
 
-        $this->assertIsInt($r->getStartMemory());
-        $this->assertIsInt($r->getEndMemory());
+        $this->assertIsFloat($r->getStartMemory());
+        $this->assertIsFloat($r->getEndMemory());
     }
 }

--- a/tests/MachineTest.php
+++ b/tests/MachineTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Result;
 use Scientist\Machine;

--- a/tests/Matchers/ClosureMatcherTest.php
+++ b/tests/Matchers/ClosureMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Matchers\ClosureMatcher;
 

--- a/tests/Matchers/StandardMatcherTest.php
+++ b/tests/Matchers/StandardMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Matchers\StandardMatcher;
 

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Result;
 use Scientist\Report;

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Scientist\Result;
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -58,7 +58,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     {
         $r = new Result;
         $r->setMatch(true);
-        $this->assertTrue(true, $r->isMatch());
+        $this->assertTrue($r->isMatch());
     }
 
     public function test_can_have_context()


### PR DESCRIPTION
I was trying to figure out what `Report->getTrial()` would return, which was quite difficult since it was hidden deep down. So I felt it would be nice to add type hints to the project.

I only added type hints which are compatible with php 7.3, as defined in the composer.json. Further improvements could be made by requiring php 7.4 (to add type hints for class properties) or php 8.0 (to add type hint `mixed`). Both don't feel really important atm. But if we anyway are okay with bumping the required php version, I could start another PR for adding those as well.

All tests are green on a php 7.3 docker.